### PR TITLE
Add version constraint to resolve clean install

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "istanbul": "^0.4.1",
     "nock": "^5.2.1",
     "nodemon": "^1.8.1",
-    "snyk": true,
+    "snyk": "^1.8.4",
     "supertest": "^1.0.1",
     "tape": "^4.0.1"
   },


### PR DESCRIPTION
Clean install fails for the snyk dev dependency. Adding an explicit version constraint resolved the install problem.