### PR TITLE
Remove tito plugin reference

### DIFF
--- a/gitevents.js
+++ b/gitevents.js
@@ -85,11 +85,6 @@ var issueHandler = function issueHandler(event) {
           }
 
         });
-        if (tito) {
-          console.log('tito ahoy');
-          tito(config.plugins[tito], payload);
-        }
-
       }
 
       // Chain for talks


### PR DESCRIPTION
`tito` is not defined and as a result and error is thrown when a request is received.