### PR TITLE
Make configuration URL placeholder more generic

### DIFF
--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -44,7 +44,7 @@ coreos:
         ExecStartPre=-/usr/bin/docker kill gitevents
         ExecStartPre=-/usr/bin/docker rm gitevents
         ExecStartPre=/usr/bin/docker pull quay.io/gitevents/gitevents
-        ExecStart=/usr/bin/docker run --name=gitevents --net=host -e "CONFIG_URL=<production.json url>" quay.io/gitevents/gitevents
+        ExecStart=/usr/bin/docker run --name=gitevents --net=host -e "CONFIG_URL=<config-url>" quay.io/gitevents/gitevents
         ExecStop=/usr/bin/docker stop gitevents
         Restart=on-failure
         RestartSec=5


### PR DESCRIPTION
I'd like to change the placeholder for the configuration gist URL to:

1. be more generic and slightly easier to parse
2. look more like a machine readable token to discourage changes

I plan on reading this file programmatically from the console application and output the correct configuration file with user specific values already baked in.